### PR TITLE
Cleaned up Bootstrap Script to be Seperated

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,14 @@ No modules.
 | [oci_identity_policy.self](https://registry.terraform.io/providers/oracle/oci/4.121.0/docs/resources/identity_policy) | resource |
 | [oci_objectstorage_bucket.self](https://registry.terraform.io/providers/oracle/oci/4.121.0/docs/resources/objectstorage_bucket) | resource |
 | [random_string.unique](https://registry.terraform.io/providers/hashicorp/random/3.5.1/docs/resources/string) | resource |
+| [oci_core_instance.self](https://registry.terraform.io/providers/oracle/oci/4.121.0/docs/data-sources/core_instance) | data source |
+| [oci_core_instance_pool_instances.self](https://registry.terraform.io/providers/oracle/oci/4.121.0/docs/data-sources/core_instance_pool_instances) | data source |
 | [oci_objectstorage_namespace.self](https://registry.terraform.io/providers/oracle/oci/4.121.0/docs/data-sources/objectstorage_namespace) | data source |
 | [template_cloudinit_config.self](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/cloudinit_config) | data source |
 | [template_file.fact_file](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.ops_file](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.server_properties_file](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
+| [template_file.minecraft_service](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
+| [template_file.modded_user_jvm_args](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
+| [template_file.rclone_conf](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
 
 ## Inputs
 
@@ -93,7 +96,6 @@ No modules.
 | <a name="input_minecraft_server_jar_download_url"></a> [minecraft\_server\_jar\_download\_url](#input\_minecraft\_server\_jar\_download\_url) | The URL that allows one to download the server JAR of their choice. Defaults to a vanilla MC server. | `string` | `"https://piston-data.mojang.com/v1/objects/8f3112a1049751cc472ec13e397eade5336ca7ae/server.jar"` | no |
 | <a name="input_parent_compartment_id"></a> [parent\_compartment\_id](#input\_parent\_compartment\_id) | The parent compartment to associate the deployment's compartment. | `string` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The name of this project | `string` | `"mc-server"` | no |
-
 | <a name="input_pub_key"></a> [pub\_key](#input\_pub\_key) | The public key to associate on the instance in order to provide SSH access | `string` | n/a | yes |
 | <a name="input_pub_subnet_block"></a> [pub\_subnet\_block](#input\_pub\_subnet\_block) | The CIDR block to use for the subnet | `string` | `"10.0.0.0/24"` | no |
 | <a name="input_region_name"></a> [region\_name](#input\_region\_name) | The name of the region | `string` | `"us-sanjose-1"` | no |
@@ -106,7 +108,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_backup_bucket_name"></a> [backup\_bucket\_name](#output\_backup\_bucket\_name) | The name of the bucket that holds world backups and mods for the server |
 | <a name="output_pub_subnet_id"></a> [pub\_subnet\_id](#output\_pub\_subnet\_id) | The OICD of the created public subnet, if it exists. |
+| <a name="output_server_public_ip"></a> [server\_public\_ip](#output\_server\_public\_ip) | The public IP of the created server in the instance pool. |
 
 ## Steps to Deploy
 

--- a/data.tf
+++ b/data.tf
@@ -149,3 +149,12 @@ resource "random_string" "unique" {
   special = false
   upper   = false
 }
+
+data "oci_core_instance_pool_instances" "self" {
+  compartment_id   = oci_identity_compartment.self.id
+  instance_pool_id = oci_core_instance_pool.self.id
+}
+
+data "oci_core_instance" "self" {
+  instance_id = data.oci_core_instance_pool_instances.self.instances[0].id
+}

--- a/data.tf
+++ b/data.tf
@@ -3,6 +3,15 @@ locals {
 
   server_properties_path = var.custom_server_properties_path == "" ? "${path.module}/templates/server.properties.tpl" : var.custom_server_properties_path
   ops_json_path          = var.custom_ops_json_path == "" ? "${path.module}/templates/ops.json.tpl" : var.custom_ops_json_path
+
+  home_folder       = "/home/minecraft"
+  server_folder     = "${local.home_folder}/server"
+  mod_folder        = "${local.server_folder}/mods"
+  service_name      = "minecraft"
+  full_service_name = var.is_modded == false ? "Minecraft Server" : "Minecraft Modded Server"
+
+  jar_name    = basename(var.minecraft_server_jar_download_url)
+  run_command = var.is_modded == false ? "/usr/bin/java -Xms${var.min_memory} -Xmx${var.max_memory} -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+ParallelRefProcEnabled -jar ${local.jar_name} nogui" : "/bin/sh run.sh"
 }
 
 data "oci_objectstorage_namespace" "self" {
@@ -20,15 +29,41 @@ data "template_file" "fact_file" {
     REGION_NAME             = var.region_name
     COMPARTMENT_ID          = oci_identity_compartment.self.id
     IS_MODDED               = var.is_modded
+    HOME_FOLDER             = local.home_folder
+    SERVER_FOLDER           = local.server_folder
+    MOD_FOLDER              = local.mod_folder
+    SERVICE_NAME            = local.service_name
+    JAR_NAME                = local.jar_name
   }
 }
 
-data "template_file" "server_properties_file" {
-  template = file(local.server_properties_path)
+data "template_file" "minecraft_service" {
+  template = file("${path.module}/templates/minecraft.service.tpl")
+
+  vars = {
+    server_folder     = "/home/minecraft/server"
+    run_command       = local.run_command
+    full_service_name = local.full_service_name
+  }
 }
 
-data "template_file" "ops_file" {
-  template = file(local.ops_json_path)
+data "template_file" "rclone_conf" {
+  template = file("${path.module}/templates/rclone.conf.tpl")
+
+  vars = {
+    bucket_namespace = data.oci_objectstorage_namespace.self.namespace
+    compartment_id   = oci_identity_compartment.self.id
+    region_name      = var.region_name
+  }
+}
+
+data "template_file" "modded_user_jvm_args" {
+  template = file("${path.module}/templates/user_jvm_args.txt.tpl")
+
+  vars = {
+    min_memory = var.min_memory
+    max_memory = var.max_memory
+  }
 }
 
 data "template_cloudinit_config" "self" {
@@ -46,16 +81,52 @@ data "template_cloudinit_config" "self" {
           permissions = "0644"
         },
         {
-          content     = data.template_file.server_properties_file.rendered
+          content     = file(local.server_properties_path)
           path        = "/etc/server.properites"
           owner       = "root:root"
           permissions = "0644"
         },
         {
-          content     = data.template_file.ops_file.rendered
+          content     = file(local.ops_json_path)
           path        = "/etc/ops.json"
           owner       = "root:root"
           permissions = "0644"
+        },
+        {
+          content     = data.template_file.rclone_conf.rendered
+          path        = "/etc/rclone.conf"
+          owner       = "root:root"
+          permissions = "0644"
+        },
+        {
+          content     = data.template_file.modded_user_jvm_args.rendered
+          path        = "/etc/user_jvm_args.txt"
+          owner       = "root:root"
+          permissions = "0644"
+        },
+        {
+          content     = data.template_file.minecraft_service.rendered
+          path        = "/etc/minecraft.service"
+          owner       = "root:root"
+          permissions = "0644"
+        },
+        {
+          content     = file("${path.module}/scripts/backup.sh")
+          path        = "/etc/backup.sh"
+          owner       = "root:root"
+          permissions = "0744"
+        },
+        {
+          content     = file("${path.module}/scripts/restore_backup.sh")
+          path        = "/etc/restore_backup.sh"
+          owner       = "root:root"
+          permissions = "0744"
+        },
+        {
+          content     = file("${path.module}/scripts/mod_refresh.sh")
+          path        = "/etc/mod_refresh.sh"
+          owner       = "root:root"
+          permissions = "0744"
         },
         {
           content     = file("${path.module}/scripts/bootstrap.sh")

--- a/output.tf
+++ b/output.tf
@@ -2,3 +2,13 @@ output "pub_subnet_id" {
   description = "The OICD of the created public subnet, if it exists."
   value       = oci_core_subnet.public.*.id
 }
+
+output "server_public_ip" {
+  description = "The public IP of the created server in the instance pool."
+  value       = data.oci_core_instance.self.public_ip
+}
+
+output "backup_bucket_name" {
+  description = "The name of the bucket that holds world backups and mods for the server"
+  value       = oci_objectstorage_bucket.self.name
+}

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source /etc/oci_facts
+
+backup_name="backup_$(date "+%Y%m%d-%H%M%S").zip"
+
+echo "Backup is in progress, please wait..."
+systemctl stop ${service_name}
+sleep 10
+(cd ${server_folder} && zip -qr ${server_folder}/${backup_name} ./world)
+oci os object put --namespace ${bucket_namespace} --bucket-name ${bucket_name} --file ${server_folder}/${backup_name} --no-multipart --auth instance_principal
+rm -f ${server_folder}/${backup_name}
+systemctl start ${service_name}
+echo "Backup, ${backup_name}, saved to bucket, ${bucket_name}. Server will restart momentarily."

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,18 +2,8 @@
 
 source /etc/oci_facts
 
-home_folder="/home/minecraft"
-server_folder="${home_folder}/server"
-mod_folder="${server_folder}/mods"
-service_name="minecraft"
-jar_name="$(basename ${minecraft_server_jar_download_url})"
-
-new_server_properties_path="/etc/server.properites"
-new_ops_path="/etc/ops.json"
-
 if [ ! -d "${server_folder}" ]; then
     echo "## Performing initial bootstrap ##"
-
     useradd -r -m -U -d ${home_folder} -s /bin/bash minecraft
     mkdir ${server_folder}
     chown -R minecraft:minecraft ${server_folder}
@@ -25,92 +15,19 @@ if [ ! -d "${server_folder}" ]; then
 
     curl https://rclone.org/install.sh | bash
 
-    echo "## Creating backup script ##"
-    cat << EOF > /etc/backup.sh
-#!/bin/bash
-backup_name="backup_\$(date "+%Y%m%d-%H%M%S").zip"
-
-echo "Backup is in progress, please wait..."
-systemctl stop ${service_name}
-sleep 10
-(cd ${server_folder} && zip -qr ${server_folder}/\${backup_name} ./world)
-oci os object put --namespace ${bucket_namespace} --bucket-name ${bucket_name} --file ${server_folder}/\${backup_name} --no-multipart --auth instance_principal
-rm -f ${server_folder}/\${backup_name}
-systemctl start ${service_name}
-echo "Backup, ${backup_name}, saved to bucket, ${bucket_name}. Server will restart momentarily."
-EOF
-    chmod +x /etc/backup.sh
-
-    echo "## Creating restore from backup script ##"
-    cat << EOF > /etc/restore_backup.sh
-#!/bin/bash
-# Pass parameter of backup name with path
-
-echo "Restoring from backup, please wait..."
-systemctl stop ${service_name}
-sleep 10
-oci os object get --namespace ${bucket_namespace} --bucket-name ${bucket_name} --name \$1 --file ${server_folder}/\$1 --auth instance_principal
-rm -rf ${server_folder}/world
-unzip -q ${server_folder}/\$1 -d ${server_folder}
-chown -R minecraft:minecraft ${server_folder}/world
-rm -rf ${server_folder}/\$1
-systemctl restart ${service_name}
-echo "Restored from backup, \$1. Server will restart momentarily."
-EOF
-    chmod +x /etc/restore_backup.sh
-    
     echo "## Download Server Jar ##"
     curl -s -O "${minecraft_server_jar_download_url}"
-    run_command="/usr/bin/java -Xms${min_memory} -Xmx${max_memory} -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+ParallelRefProcEnabled -jar ${jar_name} nogui"
     
     if [ ${is_modded} ]; then
-        echo "## Creating mod sync script ##"
-        cat << EOF > /etc/mod_refresh.sh
-#!/bin/bash
-
-echo "Syncing mods from bucket..."
-systemctl stop ${service_name}
-sleep 10
-rclone sync oos:${bucket_name}/mods ${mod_folder} --create-empty-src-dirs
-systemctl start ${service_name}
-echo "Syncing complete! Server will be restarted momentarily."
-EOF
-        chmod +x /etc/mod_refresh.sh
-
-        echo "## Creating rclone config ##"
         mkdir -p ~/.config/rclone
-        cat << EOF > ~/.config/rclone/rclone.conf
-[oos]
-type = oracleobjectstorage
-namespace = ${bucket_namespace}
-env_auth = false
-compartment = ${compartment_id}
-region = ${region_name}
-endpoint = https://${bucket_namespace}.compat.objectstorage.${region_name}.oraclecloud.com
-provider = instance_principal_auth
-EOF
-        
+        mv -f /etc/rclone.conf ~/.config/rclone/rclone.conf
+
         echo "## Installing Modded Server ##"
         /usr/bin/java -jar ${jar_name} --installServer
-        run_command="/bin/sh run.sh"
     fi
 
     echo "## Creating systemd service for minecraft ##"
-    cat << EOF > /etc/systemd/system/minecraft.service
-[Unit]
-Description=Minecraft Server
-After=local-fs.target network.target
-[Service]
-User=minecraft
-Nice=5
-TimeoutStopSec=120
-KillSignal=SIGINT
-SuccessExitStatus=0 1 130
-WorkingDirectory=${server_folder}
-ExecStart=${run_command}
-[Install]
-WantedBy=multi-user.target
-EOF
+    mv -f /etc/minecraft.service /etc/systemd/system/minecraft.service
     
     systemctl daemon-reload
     systemctl start ${service_name}
@@ -122,14 +39,8 @@ EOF
 
     if [ ${is_modded} ]; then
         echo "## Creating JVM arguments for modded server ##"
-        cat << EOF > "${server_folder}/user_jvm_args.txt"
--Xms${min_memory} 
--Xmx${max_memory} 
--XX:+UseG1GC 
--XX:+UnlockExperimentalVMOptions 
--XX:+DisableExplicitGC 
--XX:+ParallelRefProcEnabled
-EOF
+        mv -f /etc/user_jvm_args.txt "${server_folder}/user_jvm_args.txt"
+        
         echo "## Initial sync of mods ##"
         rclone sync oos:${bucket_name}/mods ${mod_folder} --create-empty-src-dirs
     fi
@@ -143,11 +54,11 @@ else
 fi
 
 echo "## Move Server and OPs files to proper location ##"
-if [ -f $new_server_properties_path ]; then
-    mv $new_server_properties_path "${server_folder}/server.properties" -f
+if [ -f /etc/server.properites ]; then
+    mv -f /etc/server.properites "${server_folder}/server.properties" -f
 fi
-if [ -f $new_ops_path ]; then
-    mv $new_ops_path "${server_folder}/ops.json" -f
+if [ -f /etc/ops.json ]; then
+    mv -f /etc/ops.json "${server_folder}/ops.json" -f
 fi
 
 echo "## Starting up Server ##"

--- a/scripts/mod_refresh.sh
+++ b/scripts/mod_refresh.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source /etc/oci_facts
+
+if [ ${is_modded} ]; then
+    echo "Syncing mods from bucket..."
+    systemctl stop ${service_name}
+    sleep 10
+    rclone sync oos:${bucket_name}/mods ${mod_folder} --create-empty-src-dirs
+    systemctl start ${service_name}
+    echo "Syncing complete! Server will be restarted momentarily."
+else
+    echo "Server is not a modded server!"
+fi

--- a/scripts/restore_backup.sh
+++ b/scripts/restore_backup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Pass parameter of backup name with path
+
+source /etc/oci_facts
+
+echo "Restoring from backup, please wait..."
+systemctl stop ${service_name}
+sleep 10
+oci os object get --namespace ${bucket_namespace} --bucket-name ${bucket_name} --name $1 --file ${server_folder}/$1 --auth instance_principal
+rm -rf ${server_folder}/world
+unzip -q ${server_folder}/$1 -d ${server_folder}
+chown -R minecraft:minecraft ${server_folder}/world
+rm -rf ${server_folder}/$1
+systemctl restart ${service_name}
+echo "Restored from backup, $1. Server will restart momentarily."

--- a/templates/minecraft.service.tpl
+++ b/templates/minecraft.service.tpl
@@ -1,0 +1,13 @@
+[Unit]
+Description=${full_service_name}
+After=local-fs.target network.target
+[Service]
+User=minecraft
+Nice=5
+TimeoutStopSec=120
+KillSignal=SIGINT
+SuccessExitStatus=0 1 130
+WorkingDirectory=${server_folder}
+ExecStart=${run_command}
+[Install]
+WantedBy=multi-user.target

--- a/templates/oci_facts.tpl
+++ b/templates/oci_facts.tpl
@@ -7,4 +7,10 @@ export bucket_name="${BUCKET_NAME}"
 export min_memory="${MIN_MEMORY}"
 export max_memory="${MAX_MEMORY}"
 export minecraft_server_jar_download_url="${SERVER_JAR_DOWNLOAD_URL}"
+export jar_name="${JAR_NAME}"
 export is_modded=${IS_MODDED}
+
+export home_folder="${HOME_FOLDER}"
+export server_folder="${SERVER_FOLDER}"
+export mod_folder="${MOD_FOLDER}"
+export service_name="${SERVICE_NAME}"

--- a/templates/rclone.conf.tpl
+++ b/templates/rclone.conf.tpl
@@ -1,0 +1,8 @@
+[oos]
+type = oracleobjectstorage
+namespace = ${bucket_namespace}
+env_auth = false
+compartment = ${compartment_id}
+region = ${region_name}
+endpoint = https://${bucket_namespace}.compat.objectstorage.${region_name}.oraclecloud.com
+provider = instance_principal_auth

--- a/templates/user_jvm_args.txt.tpl
+++ b/templates/user_jvm_args.txt.tpl
@@ -1,0 +1,6 @@
+-Xms${min_memory} 
+-Xmx${max_memory} 
+-XX:+UseG1GC 
+-XX:+UnlockExperimentalVMOptions 
+-XX:+DisableExplicitGC 
+-XX:+ParallelRefProcEnabled


### PR DESCRIPTION
This PR does a lot of housecleaning, but also making sure that the readability of the module is still in tack. Specifically:
- Made all of the inline file creations in the bootstrap is no longer happening
- Created templates for all of the configs in the deployment to be interpolated in via cloud-init
- Added helpful output to get public IP of instances in the pool in TF; no need to go into OCI console