### PR TITLE
Fixed some additional typos into bucket and fixed lifecycle policy

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -31,6 +31,11 @@ resource "oci_objectstorage_object_lifecycle_policy" "self" {
       inclusion_patterns = [
         "*.zip",
       ]
+
+      exclusion_patterns  = [
+        "config/*",
+        "mods/*"
+      ]
     }
   }
 
@@ -43,7 +48,6 @@ resource "oci_objectstorage_object" "bootstrap_config" {
   bucket    = oci_objectstorage_bucket.self.name
   namespace = data.oci_objectstorage_namespace.self.namespace
 
-  source      = data.archive_file.bootstrap_config.output_path
+  content      = filebase64(data.archive_file.bootstrap_config.output_path)
   object      = local.bootstrap_config_zip_prefix
-  content_md5 = data.archive_file.bootstrap_config.output_md5
 }


### PR DESCRIPTION
This PR does the following:
- Adds new exclusion rule to ensure that only backups are cleaned up, not config files
- Changed oci_object storage to use content hash to upload object